### PR TITLE
feat: update browser tab title with speed and tempo

### DIFF
--- a/src/components/Metronome.tsx
+++ b/src/components/Metronome.tsx
@@ -50,6 +50,15 @@ function Metronome(): React.ReactElement {
     }
   }, [state.isPlaying, state.bpm, state.timeSignature]);
 
+  // 更新瀏覽器標題以反映速度和拍子
+  useEffect(() => {
+    if (state.isPlaying) {
+      document.title = `節拍器 - 速度: ${state.bpm} BPM, 拍子: ${state.timeSignature}`;
+    } else {
+      document.title = '節拍器';
+    }
+  }, [state.isPlaying, state.bpm, state.timeSignature]);
+
   // 處理速度變化
   const handleSpeedChange = (bpm: number): void => {
     setState((prev) => ({ ...prev, bpm }));


### PR DESCRIPTION
Fixes #1

Implements browser tab title updates to reflect user interactions with speed (速度) and tempo (拍子) controls when the metronome is running.

## Changes
- Add useEffect to update document.title when isPlaying state changes
- Show current BPM and time signature in tab title while playing
- Reset to default title when stopped

## Testing
1. Start the metronome by clicking "開始"
2. Adjust speed using the slider - browser tab should update
3. Change tempo using the buttons - browser tab should update
4. Stop the metronome - tab title resets to default

Generated with [Claude Code](https://claude.ai/code)